### PR TITLE
Require protocol version 3 in handshake

### DIFF
--- a/vangers-srv/src/client.rs
+++ b/vangers-srv/src/client.rs
@@ -229,8 +229,8 @@ async fn auth(stream: &mut TcpStream) -> Result<u8, AuthError> {
 
                 let protocol_version = buff[pos + 1];
 
-                if !matches!(protocol_version, 1 | 2) {
-                    Err(HsUnexpectedProtocolVersion(&[1, 2], protocol_version))?
+                if protocol_version != 3 {
+                    Err(HsUnexpectedProtocolVersion(&[3], protocol_version))?
                 }
 
                 let send = HS_OUT


### PR DESCRIPTION
## Summary
- require protocol version 3 during the Rust server handshake

## Why
The current C++ client/server pair already moved the multiplayer wire format to protocol v3. In particular, `NID::VANGER` packets now carry a 16-bit screen-size field, so accepting protocol 1 or 2 would advertise compatibility with clients that use a different layout.

This PR makes the Rust server reject old protocol versions until explicit backward-compatible parsing is implemented.

## Testing
- `cargo test -q -p vangers-srv`
