### PR TITLE
Reject UPDATE_OBJECT from non-owners

### DIFF
--- a/vangers-srv/src/server/callback/update_object.rs
+++ b/vangers-srv/src/server/callback/update_object.rs
@@ -17,6 +17,8 @@ pub enum UpdateObjectError {
     VanjectNotFound(i32),
     #[error("player with `client_id`={0} not bind")]
     PlayerNotBind(ClientID),
+    #[error("vanject with `id`={0} is not owned by player_bind_id={1}")]
+    NotOwner(i32, u8),
 }
 
 #[allow(non_camel_case_types)]
@@ -56,6 +58,10 @@ impl OnUpdate_UpdateObject for Server {
 
         match game.vanjects.get_mut(&vanject_id) {
             Some(vanject) => {
+                if vanject.player_bind_id != player_bind_id {
+                    Err(UpdateObjectError::NotOwner(vanject_id, player_bind_id))?;
+                }
+
                 vanject
                     .update_from_slice(&packet.data)
                     .map_err(UpdateObjectError::SliceToVanjectParse)?;
@@ -83,5 +89,70 @@ impl OnUpdate_UpdateObject for Server {
         }
 
         Ok(OnUpdateOk::Complete)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::Game;
+    use crate::player::Player;
+    use crate::vanject::Vanject;
+
+    fn make_server_with_owned_vanject() -> (Server, ClientID, ClientID, i32) {
+        let mut srv = Server::new(Default::default());
+        let mut game = Game::new(1);
+
+        let owner_client: ClientID = 11;
+        let other_client: ClientID = 22;
+        game.attach_player(Player::new(owner_client));
+        game.attach_player(Player::new(other_client));
+
+        let mut vanject = Vanject::create_from_slice(&[
+            2, 1, 1, 1, // id
+            6, 0, 0, 0, // time
+            10, 0, // x
+            20, 0, // y
+            15, 0, // radius
+            1, 2, 3,
+        ])
+        .unwrap();
+        vanject.player_bind_id = 1;
+        let vanject_id = vanject.id;
+        game.vanjects.insert(vanject_id, vanject);
+
+        srv.games.insert(1, game);
+        (srv, owner_client, other_client, vanject_id)
+    }
+
+    #[test]
+    fn rejects_updates_from_non_owner() {
+        let (mut srv, _owner_client, other_client, vanject_id) = make_server_with_owned_vanject();
+        let packet = Packet::new(
+            Action::UPDATE_OBJECT,
+            &[
+                2, 1, 1, 1, // id
+                7, 0, 0, 0, // time
+                11, 0, // x
+                21, 0, // y
+                9, 9,
+            ],
+        );
+
+        let err = srv.update_object(&packet, other_client).unwrap_err();
+        match err {
+            OnUpdateError::UpdateObjectError(UpdateObjectError::NotOwner(id, bind_id)) => {
+                assert_eq!(id, vanject_id);
+                assert_eq!(bind_id, 2);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        let game = srv.games.get(&1).unwrap();
+        let vanject = game.vanjects.get(&vanject_id).unwrap();
+        assert_eq!(vanject.time, 6);
+        assert_eq!(vanject.pos.x, 10);
+        assert_eq!(vanject.pos.y, 20);
+        assert_eq!(vanject.player_bind_id, 1);
     }
 }


### PR DESCRIPTION
## Summary
- reject `UPDATE_OBJECT` for vanjects not owned by the sending player
- add a regression test that keeps the original vanject state intact after a foreign update attempt

## Why
The current callback updates any vanject in `game.vanjects` by id, even when the object belongs to another player. That lets one client mutate another player's objects as long as it knows the object id.

This PR adds an owner check against the stored `player_bind_id` before applying the update payload.

## Testing
- `cargo test -q -p vangers-srv`
