### PR TITLE
Propagate unexpected leave_world errors on CLOSE_SOCKET

### DIFF
--- a/vangers-srv/src/server/callback/close_socket.rs
+++ b/vangers-srv/src/server/callback/close_socket.rs
@@ -4,7 +4,7 @@ use crate::protocol::{Action, Packet};
 use crate::Server;
 use crate::client::ClientID;
 
-use super::{OnUpdate_LeaveWorld, OnUpdateError, OnUpdateOk};
+use super::{LeaveWorldError, OnUpdate_LeaveWorld, OnUpdateError, OnUpdateOk};
 
 #[derive(Debug, ::thiserror::Error)]
 pub enum CloseSocketError {
@@ -34,7 +34,11 @@ impl OnUpdate_CloseSocket for Server {
         packet: &Packet,
         client_id: ClientID,
     ) -> Result<OnUpdateOk, OnUpdateError> {
-        self.leave_world(packet, client_id).ok();
+        match self.leave_world(packet, client_id) {
+            Ok(_) => {}
+            Err(OnUpdateError::LeaveWorldError(LeaveWorldError::WorldEmpty(_))) => {}
+            Err(err) => return Err(err),
+        }
 
         let game = match self.get_mut_game_by_clientid(client_id) {
             Some(game) => game,
@@ -72,5 +76,40 @@ impl OnUpdate_CloseSocket for Server {
         }
 
         Ok(OnUpdateOk::Complete)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::{Game, World};
+    use crate::player::Player;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn close_socket_propagates_leave_world_failures() {
+        let mut srv = Server::new(Default::default());
+        let mut game = Game::new(1);
+        let client_id: ClientID = 11;
+        game.attach_player(Player::new(client_id));
+
+        let world = Rc::new(RefCell::new(World::new(1, 100)));
+        game.worlds.push(Rc::clone(&world));
+        game.place_player(client_id, &world.borrow());
+
+        srv.games.insert(1, game);
+
+        let _borrow_guard = world.borrow_mut();
+        let err = srv
+            .close_socket(&Packet::new(Action::CLOSE_SOCKET, &[]), client_id)
+            .unwrap_err();
+
+        match err {
+            OnUpdateError::LeaveWorldError(LeaveWorldError::BorrowWorld(id, _)) => {
+                assert_eq!(id, client_id);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- stop swallowing unexpected `leave_world()` errors during `CLOSE_SOCKET`
- keep `WorldEmpty` as the only intentionally ignored case
- add a regression test for the masked `BorrowWorld` failure path

## Why
`close_socket()` currently calls `leave_world(...).ok()`, so world-cleanup failures are silently discarded. That makes stale state after disconnects much harder to diagnose and lets the server continue after a broken cleanup path.

This PR preserves the benign "already out of world" case but propagates real cleanup failures.

## Testing
- `cargo test -q -p vangers-srv`
