### PR TITLE
Send only global vanjects during ATTACH_TO_GAME

### DIFF
--- a/vangers-srv/src/server/callback/attach_to_game.rs
+++ b/vangers-srv/src/server/callback/attach_to_game.rs
@@ -97,7 +97,7 @@ impl OnUpdate_AttachToGame for Server {
         let packets = game
             .vanjects
             .values()
-            // .filter(|v| !v.is_non_global())
+            .filter(|v| !v.is_non_global())
             .map(|v| v.to_vangers_byte())
             .map(|v| Packet::new(Action::UPDATE_OBJECT, &v[..]))
             .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary
- restrict `ATTACH_TO_GAME` object replay to global vanjects only

## Why
The current Rust server replays every `game.vanject` to a newly attached client, including world-local and stale non-global objects. The original C++ server only sends the global object set during the attach step and defers world-local state until `SET_WORLD`.

This PR brings the initial attach replay closer to the original behavior and avoids off-world garbage at connect time.

## Testing
- `cargo test -q -p vangers-srv`
