### PR TITLE
Skip foreign player inventory during SET_WORLD replay

### DIFF
--- a/vangers-srv/src/server/callback/set_world.rs
+++ b/vangers-srv/src/server/callback/set_world.rs
@@ -82,8 +82,7 @@ impl OnUpdate_SetWorld for Server {
             .filter(|(_, v)| {
                 v.get_type() != NID::VANGER
                     && v.get_world() == world_id as i32
-                    // && v.get_station() != player_bind_id as i32 // it is REAL not need con
-                    && (!v.is_players() || v.is_players() && v.is_non_global())
+                    && !v.is_players()
             })
             .map(|(_, v)| Packet::new(Action::UPDATE_OBJECT, &v.to_vangers_byte()))
             .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary
- stop replaying player-owned inventory/slot objects during `SET_WORLD`

## Why
The current `SET_WORLD` path sends every non-vanger object in the world, including player-owned inventory objects from other players. The original C++ server only reveals that inventory state when visibility rules say it should be visible.

Until the Rust server has the same visibility pipeline, the safer behavior is to skip player-owned objects during the initial world replay.

## Testing
- `cargo test -q -p vangers-srv`
