### PR TITLE
Stop broadcasting PLAYERS_POSITION on every vanger update

### DIFF
--- a/vangers-srv/src/server/callback/create_object.rs
+++ b/vangers-srv/src/server/callback/create_object.rs
@@ -4,7 +4,7 @@ use ::tracing::{debug, warn};
 
 use crate::Server;
 use crate::client::ClientID;
-use crate::protocol::{Action, NetTransportSend, Packet};
+use crate::protocol::{Action, Packet};
 use crate::vanject::*;
 
 use super::{OnUpdateError, OnUpdateOk};
@@ -61,16 +61,7 @@ impl OnUpdate_CreateObject for Server {
                 } else {
                     let data = vanject.to_vangers_byte();
                     let answer = Packet::new(Action::UPDATE_OBJECT, &data);
-
-                    let data = std::iter::empty()
-                        .chain(&[vanject.player_bind_id])
-                        .chain(&vanject.pos.to_vangers_byte())
-                        .copied()
-                        .collect::<Vec<_>>();
-                    let player_position = Packet::new(Action::PLAYERS_POSITION, &data);
-
                     self.notify_game(client_id, &answer);
-                    self.notify_game(client_id, &player_position);
                 }
             } else {
                 // #IF: vanject.get_type() != NID::VANGER

--- a/vangers-srv/src/server/callback/update_object.rs
+++ b/vangers-srv/src/server/callback/update_object.rs
@@ -1,6 +1,6 @@
 use crate::Server;
-use crate::protocol::{Action, NetTransportSend, Packet};
-use crate::vanject::{NID, VanjectError};
+use crate::protocol::{Action, Packet};
+use crate::vanject::VanjectError;
 use crate::{client::ClientID, utils::slice_le_to_i32};
 
 use super::{OnUpdateError, OnUpdateOk};
@@ -52,8 +52,6 @@ impl OnUpdate_UpdateObject for Server {
             .map(|bind| bind.id())
             .ok_or(UpdateObjectError::PlayerNotBind(client_id))?;
 
-        let mut packets: Vec<Packet> = vec![];
-
         match game.vanjects.get_mut(&vanject_id) {
             Some(vanject) => {
                 vanject
@@ -61,25 +59,10 @@ impl OnUpdate_UpdateObject for Server {
                     .map_err(UpdateObjectError::SliceToVanjectParse)?;
 
                 vanject.player_bind_id = player_bind_id;
-                if vanject.get_type() == NID::VANGER {
-                    let data = std::iter::empty()
-                        .chain(&[vanject.player_bind_id])
-                        .chain(&vanject.pos.to_vangers_byte())
-                        .copied()
-                        .collect::<Vec<_>>();
-                    packets.push(Packet::new(Action::PLAYERS_POSITION, &data));
-                }
-
-                packets.push(Packet::new(
-                    Action::UPDATE_OBJECT,
-                    &vanject.to_vangers_byte(),
-                ));
+                let packet = Packet::new(Action::UPDATE_OBJECT, &vanject.to_vangers_byte());
+                self.notify_game(client_id, &packet);
             }
             None => Err(UpdateObjectError::VanjectNotFound(vanject_id))?,
-        }
-
-        for p in packets {
-            self.notify_game(client_id, &p);
         }
 
         Ok(OnUpdateOk::Complete)


### PR DESCRIPTION
## Summary
- stop emitting `PLAYERS_POSITION` from vanger `CREATE_OBJECT` and `UPDATE_OBJECT` callbacks
- keep vanger object sync on the normal `UPDATE_OBJECT` path only

## Why
The Rust server currently broadcasts `PLAYERS_POSITION` on every vanger create/update, which is much noisier than the original server and creates extra auxiliary races in the client player list state machine.

This PR removes that eager auxiliary traffic and leaves position/state updates on the regular object stream.

## Testing
- `cargo test -q -p vangers-srv`
