### PR TITLE
Include finished players in TOTAL_LIST_OF_PLAYERS_DATA

### DIFF
--- a/vangers-srv/src/game/game.rs
+++ b/vangers-srv/src/game/game.rs
@@ -6,7 +6,8 @@ use std::rc::Rc;
 
 use crate::client::ClientID;
 use crate::player::{Player, Status as PlayerStatus};
-use crate::protocol::NetTransportReceive;
+use crate::protocol::{NetTransportReceive, NetTransportSend};
+use crate::vanject::Pos;
 use crate::utils::Uptime;
 use crate::vanject::Vanject;
 
@@ -23,6 +24,7 @@ pub struct Game {
     pub id: GameID,
     pub name: Vec<u8>,
     pub players: Vec<Player>,
+    pub removed_players: Vec<RemovedPlayer>,
     pub worlds: Vec<Rc<RefCell<World>>>,
     pub birth_time: Uptime,
     pub config: Option<Config>,
@@ -44,6 +46,7 @@ impl std::fmt::Debug for Game {
             .field("name", &name)
             .field("birth_time", &self.birth_time)
             .field("players", &self.players)
+            .field("removed_players", &self.removed_players)
             .field("worlds", &self.worlds)
             .field("config", &self.config)
             .field("vanjects_count", &self.vanjects.len())
@@ -61,6 +64,7 @@ impl Game {
             id,
             name: vec![],
             players: vec![],
+            removed_players: vec![],
             worlds: vec![],
             birth_time: Uptime::new(),
             config: None, // used_players_ids: 0,
@@ -200,6 +204,7 @@ impl Game {
     pub fn attach_player(&mut self, mut p: Player) -> Option<u8> {
         match self.get_uniq_player_id() {
             Some(uniq_id) if uniq_id > 0 => {
+                self.removed_players.retain(|player| player.bind_id != uniq_id);
                 p.set_bind(uniq_id);
                 self.players.push(p);
                 Some(uniq_id)
@@ -226,5 +231,37 @@ impl Game {
             Some(ref a) => a.get_gametype(),
             _ => Type::UNCONFIGURED,
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct RemovedPlayer {
+    pub bind_id: u8,
+    pub status: PlayerStatus,
+    pub world: u8,
+    pub pos: Pos<i16>,
+    pub name: Vec<u8>,
+    pub body: Vec<u8>,
+}
+
+impl RemovedPlayer {
+    pub fn from_player(player: &Player) -> Option<Self> {
+        let bind_id = player.bind.map(|bind| bind.id())?;
+        let name = player.auth.as_ref()?.name().to_vec();
+        let body = player.body.as_ref()?.to_vangers_byte();
+        let world = player
+            .world
+            .as_ref()
+            .map(|world| world.borrow().id)
+            .unwrap_or(0);
+
+        Some(Self {
+            bind_id,
+            status: player.status,
+            world,
+            pos: player.pos,
+            name,
+            body,
+        })
     }
 }

--- a/vangers-srv/src/server/callback/close_socket.rs
+++ b/vangers-srv/src/server/callback/close_socket.rs
@@ -41,22 +41,32 @@ impl OnUpdate_CloseSocket for Server {
             None => return Err(CloseSocketError::PlayerNotFound(client_id).into()),
         };
 
-        let player = game.get_mut_player(client_id).unwrap();
-        let player_bind_id = match player.bind {
-            Some(bind) => bind.id(),
-            None => return Err(CloseSocketError::PlayerNotBind(client_id).into()),
-        };
+        let mut finished_packet = None;
+        {
+            let player = game.get_mut_player(client_id).unwrap();
+            let player_bind_id = match player.bind {
+                Some(bind) => bind.id(),
+                None => return Err(CloseSocketError::PlayerNotBind(client_id).into()),
+            };
 
-        player.world = None;
-        if player.status == PlayerStatus::GAMING {
-            player.status = PlayerStatus::FINISHED;
-            self.notify_game(
-                client_id,
-                &Packet::new(
+            player.world = None;
+            if player.status == PlayerStatus::GAMING {
+                player.status = PlayerStatus::FINISHED;
+                finished_packet = Some(Packet::new(
                     Action::PLAYERS_STATUS,
                     &[player_bind_id, PlayerStatus::FINISHED as u8],
-                ),
-            );
+                ));
+            }
+
+            if let Some(snapshot) = crate::game::RemovedPlayer::from_player(player) {
+                game.removed_players
+                    .retain(|removed| removed.bind_id != snapshot.bind_id);
+                game.removed_players.push(snapshot);
+            }
+        }
+
+        if let Some(packet) = finished_packet {
+            self.notify_game(client_id, &packet);
         }
 
         let game = self.get_mut_game_by_clientid(client_id).unwrap();

--- a/vangers-srv/src/server/callback/total_players_data_query.rs
+++ b/vangers-srv/src/server/callback/total_players_data_query.rs
@@ -33,7 +33,7 @@ impl OnUpdate_TotalPlayersDataQuery for Server {
             None => return Err(TotalPlayersDataQueryError::PlayerNotFound(client_id).into()),
         };
 
-        let mut data = vec![game.players.len() as u8];
+        let mut data = vec![(game.players.len() + game.removed_players.len()) as u8];
         let mut players_count = 0;
         for player in &game.players {
             let id = match player.bind {
@@ -79,11 +79,71 @@ impl OnUpdate_TotalPlayersDataQuery for Server {
             players_count += 1;
         }
 
+        for player in &game.removed_players {
+            let mut p_data = std::iter::empty()
+                .chain(&[player.bind_id])
+                .chain(&[player.status as u8])
+                .chain(&[player.world])
+                .chain(&player.pos.to_vangers_byte())
+                .chain(&player.name)
+                .chain(&player.body)
+                .copied()
+                .collect::<Vec<_>>();
+
+            data.append(&mut p_data);
+            players_count += 1;
+        }
+
         data[0] = players_count;
 
         packet
             .create_answer(data)
             .map(OnUpdateOk::Response)
             .ok_or(OnUpdateError::ResponsePacketTypeNotExist(packet.action))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::game::{Game, RemovedPlayer};
+    use crate::player::{Body, Player, Status};
+    use crate::protocol::Action;
+    use crate::vanject::Pos;
+
+    #[test]
+    fn includes_removed_players_in_full_snapshot() {
+        let mut srv = Server::new(Default::default());
+        let mut game = Game::new(1);
+
+        let client_id: ClientID = 11;
+        let mut live_player = Player::new(client_id);
+        live_player.set_auth(b"live\0", b"\0");
+        live_player.body = Some(Body::default());
+        game.attach_player(live_player);
+
+        game.removed_players.push(RemovedPlayer {
+            bind_id: 2,
+            status: Status::FINISHED,
+            world: 0,
+            pos: Pos { x: 10, y: 20 },
+            name: b"gone\0".to_vec(),
+            body: Body::default().to_vangers_byte(),
+        });
+
+        srv.games.insert(1, game);
+
+        let response = srv
+            .total_players_data_query(&Packet::new(Action::TOTAL_PLAYERS_DATA_QUERY, &[]), client_id)
+            .unwrap();
+
+        match response {
+            OnUpdateOk::Response(packet) => {
+                assert_eq!(packet.action, Action::TOTAL_LIST_OF_PLAYERS_DATA);
+                assert_eq!(packet.data[0], 2);
+                assert!(packet.data.windows(b"gone\0".len()).any(|w| w == b"gone\0"));
+            }
+            other => panic!("unexpected response: {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- keep a removed-player snapshot in `Game` when a client disconnects
- include those finished players in `TOTAL_LIST_OF_PLAYERS_DATA`
- drop stale removed snapshots when the same bind id is reused
- add a regression test for finished-player inclusion in the full snapshot

## Why
The Rust server currently removes disconnected players from `game.players` immediately, so a later `TOTAL_PLAYERS_DATA_QUERY` cannot restore the missing `FINISHED` state if the client missed the original `PLAYERS_STATUS FINISHED` event.

This PR keeps a lightweight removed-player snapshot for resync purposes and includes it in the full player list response.

## Testing
- `cargo test -q -p vangers-srv`
