### PR TITLE
Route non-global object traffic by world and send HIDE on leave

### DIFF
--- a/vangers-srv/src/server/callback/create_object.rs
+++ b/vangers-srv/src/server/callback/create_object.rs
@@ -69,8 +69,13 @@ impl OnUpdate_CreateObject for Server {
                         .collect::<Vec<_>>();
                     let player_position = Packet::new(Action::PLAYERS_POSITION, &data);
 
-                    self.notify_game(client_id, &answer);
-                    self.notify_game(client_id, &player_position);
+                    self.notify_world(client_id, vanject.get_world() as u8, &answer, false);
+                    self.notify_world(
+                        client_id,
+                        vanject.get_world() as u8,
+                        &player_position,
+                        false,
+                    );
                 }
             } else {
                 // #IF: vanject.get_type() != NID::VANGER
@@ -79,7 +84,11 @@ impl OnUpdate_CreateObject for Server {
 
                 if !vanject.is_players() {
                     // world->process_create;
-                    self.notify_game(client_id, &answer);
+                    if vanject.is_non_global() {
+                        self.notify_world(client_id, vanject.get_world() as u8, &answer, false);
+                    } else {
+                        self.notify_game(client_id, &answer);
+                    }
                 } else {
                     if vanject.is_non_global() {
                         // world->process_create_inventory()
@@ -88,7 +97,7 @@ impl OnUpdate_CreateObject for Server {
                             &vanject.id.to_le_bytes(),
                             vanject.player_bind_id
                         );
-                        self.notify_game(client_id, &answer);
+                        self.notify_world(client_id, vanject.get_world() as u8, &answer, false);
                     } else {
                         // game->process_create_globals()
                         self.notify_game(client_id, &answer);

--- a/vangers-srv/src/server/callback/delete_object.rs
+++ b/vangers-srv/src/server/callback/delete_object.rs
@@ -76,7 +76,16 @@ impl OnUpdate_DeleteObject for Server {
             debug!("VANJECT with id=`{}` not found", vanject_id);
         }
 
-        self.notify_game(client_id, &answer);
+        if crate::vanject::is_non_global_vanject(vanject_id) {
+            self.notify_world(
+                client_id,
+                crate::vanject::get_world(vanject_id) as u8,
+                &answer,
+                false,
+            );
+        } else {
+            self.notify_game(client_id, &answer);
+        }
         Ok(OnUpdateOk::Complete)
     }
 }

--- a/vangers-srv/src/server/callback/leave_world.rs
+++ b/vangers-srv/src/server/callback/leave_world.rs
@@ -45,7 +45,7 @@ impl OnUpdate_LeaveWorld for Server {
             None => return Err(LeaveWorldError::PlayerNotBind(client_id).into()),
         };
 
-        let _world_id = match player.world {
+        let world_id = match player.world {
             Some(ref world) => match world.try_borrow() {
                 Ok(w) => w.id,
                 Err(e) => return Err(LeaveWorldError::BorrowWorld(client_id, e).into()),
@@ -74,10 +74,21 @@ impl OnUpdate_LeaveWorld for Server {
             })
             .collect::<HashMap<_, _>>();
 
+        let hide = game
+            .vanjects
+            .iter()
+            .filter(|(_, v)| v.is_non_global() && v.get_world() == world_id as i32)
+            .map(|(&id, _)| Packet::new(Action::HIDE_OBJECT, &id.to_le_bytes()))
+            .collect::<Vec<_>>();
+
         game.vanjects.retain(|id, _| !delete.contains_key(id));
 
         for (_, packet) in delete {
             self.notify_game(client_id, &packet);
+        }
+
+        for packet in hide {
+            self.notify_player(client_id, &packet);
         }
 
         // That sends by github server, but it seems to may be safety removed at all

--- a/vangers-srv/src/server/callback/update_object.rs
+++ b/vangers-srv/src/server/callback/update_object.rs
@@ -78,8 +78,18 @@ impl OnUpdate_UpdateObject for Server {
             None => Err(UpdateObjectError::VanjectNotFound(vanject_id))?,
         }
 
+        let world_id = if vanject_id != 0 {
+            crate::vanject::get_world(vanject_id) as u8
+        } else {
+            0
+        };
+
         for p in packets {
-            self.notify_game(client_id, &p);
+            if crate::vanject::is_non_global_vanject(vanject_id) {
+                self.notify_world(client_id, world_id, &p, false);
+            } else {
+                self.notify_game(client_id, &p);
+            }
         }
 
         Ok(OnUpdateOk::Complete)

--- a/vangers-srv/src/server/server.rs
+++ b/vangers-srv/src/server/server.rs
@@ -155,6 +155,32 @@ impl Server {
         self.notify(client_id, packet, Box::new(|_| true));
     }
 
+    /// Sends `packet` to players that are currently attached to the same world.
+    pub fn notify_world(
+        &self,
+        client_id: ClientID,
+        world_id: u8,
+        packet: &Packet,
+        include_sender: bool,
+    ) {
+        let game = match self.get_game_by_clientid(client_id) {
+            Some(game) => game,
+            None => {
+                error!(
+                    "cannot doing notify_world: player with client_id=`{}` not found on the server",
+                    client_id
+                );
+                return;
+            }
+        };
+
+        let client_ids = client_ids_in_world(game, world_id, Some(client_id), include_sender);
+        self.clients
+            .iter()
+            .filter(|c| client_ids.contains(&c.id))
+            .for_each(|c| c.send(packet));
+    }
+
     pub async fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let (client_tx, mut clients_rx) = mpsc::channel(50);
         let (event_tx, mut event_rx) = mpsc::channel::<Event>(10);
@@ -231,5 +257,54 @@ impl Server {
 
             }
         }
+    }
+}
+
+fn client_ids_in_world(
+    game: &Game,
+    world_id: u8,
+    sender_id: Option<ClientID>,
+    include_sender: bool,
+) -> Vec<ClientID> {
+    game.players
+        .iter()
+        .filter(|player| {
+            player
+                .world
+                .as_ref()
+                .map(|world| world.borrow().id == world_id)
+                .unwrap_or(false)
+        })
+        .filter(|player| include_sender || Some(player.client_id) != sender_id)
+        .map(|player| player.client_id)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::client_ids_in_world;
+    use crate::game::{Game, World};
+    use crate::player::Player;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn selects_only_players_from_requested_world() {
+        let mut game = Game::new(1);
+        game.attach_player(Player::new(11));
+        game.attach_player(Player::new(22));
+
+        let world1 = Rc::new(RefCell::new(World::new(1, 100)));
+        let world2 = Rc::new(RefCell::new(World::new(2, 100)));
+        game.worlds.push(Rc::clone(&world1));
+        game.worlds.push(Rc::clone(&world2));
+        game.place_player(11, &world1.borrow());
+        game.place_player(22, &world2.borrow());
+
+        let ids = client_ids_in_world(&game, 1, Some(11), false);
+        assert!(ids.is_empty());
+
+        let ids = client_ids_in_world(&game, 1, Some(11), true);
+        assert_eq!(ids, vec![11]);
     }
 }


### PR DESCRIPTION
## Summary
- add world-scoped routing for non-global object create/update/delete traffic
- stop broadcasting world-local vanject events to the entire game
- send `HIDE_OBJECT` packets for the old world's non-global objects when a player leaves that world
- add a regression test for the world-based recipient selector

## Why
The Rust server currently treats most object traffic as whole-game broadcast traffic. That is much broader than the original server model, which gates world-local objects by visibility and sends hide events when objects stop being relevant.

This PR adds a first server-side visibility/HIDE foundation:
- non-global vanject traffic is routed only to players in the same world
- leaving a world now hides that world's local objects from the departing client

It is not a full pixel-perfect clone of the original visibility code, but it removes the biggest architectural mismatch: world-local object traffic being broadcast to unrelated worlds.

## Testing
- `cargo test -q -p vangers-srv`
